### PR TITLE
Update rand to 0.8.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file contains all changes to the crate since version v0.1.0.
 
+## [1.5.1] - 2026-04-17
+
+- Update `rand` to version 0.8.6.
+
 ## [1.5.0] - 2026-04-13
 
 - Update dev-dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "compile_time_sort"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "paste",
  "quickcheck",
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ rustversion = "1.0.22"
 paste = "1.0.15"
 
 [dev-dependencies]
-rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
+rand = { version = "0.8.6", default-features = false, features = ["small_rng"] }
 quickcheck = { version = "=1.0.3", default-features = false }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compile_time_sort"
-version = "1.5.0"
+version = "1.5.1"
 edition = "2021"
 description = "Sort arrays and slices of primitives in const contexts."
 keywords = ["const", "sort", "const-sort", "sorting"]


### PR DESCRIPTION
Version 0.8.5 is unsound (https://github.com/rust-random/rand/pull/1763).